### PR TITLE
NCBC-1685: Add enterprise license to footer

### DIFF
--- a/src/Couchbase.Extensions.Encryption/ClientConfigurationExtensions.cs
+++ b/src/Couchbase.Extensions.Encryption/ClientConfigurationExtensions.cs
@@ -33,23 +33,14 @@ namespace Couchbase.Extensions.Encryption
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/CryptoManager.cs
+++ b/src/Couchbase.Extensions.Encryption/CryptoManager.cs
@@ -29,3 +29,14 @@ namespace Couchbase.Extensions.Encryption
         }
     }
 }
+#region [License information]
+/* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
+ *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
+ * ************************************************************/
+#endregion

--- a/src/Couchbase.Extensions.Encryption/CryptoProviderBase.cs
+++ b/src/Couchbase.Extensions.Encryption/CryptoProviderBase.cs
@@ -28,23 +28,14 @@ namespace Couchbase.Extensions.Encryption
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/CryptoProviderNotFoundException.cs
+++ b/src/Couchbase.Extensions.Encryption/CryptoProviderNotFoundException.cs
@@ -24,3 +24,15 @@ namespace Couchbase.Extensions.Encryption
         public string ProviderName { get; set; }
     }
 }
+
+#region [License information]
+/* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
+ *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
+ * ************************************************************/
+#endregion

--- a/src/Couchbase.Extensions.Encryption/EncryptedFieldAttribute.cs
+++ b/src/Couchbase.Extensions.Encryption/EncryptedFieldAttribute.cs
@@ -9,23 +9,14 @@ namespace Couchbase.Extensions.Encryption
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/EncryptedFieldContractResolver.cs
+++ b/src/Couchbase.Extensions.Encryption/EncryptedFieldContractResolver.cs
@@ -76,23 +76,14 @@ namespace Couchbase.Extensions.Encryption
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/EncryptedFieldConverter.cs
+++ b/src/Couchbase.Extensions.Encryption/EncryptedFieldConverter.cs
@@ -178,23 +178,14 @@ namespace Couchbase.Extensions.Encryption
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/EncryptedFieldSerializer.cs
+++ b/src/Couchbase.Extensions.Encryption/EncryptedFieldSerializer.cs
@@ -15,23 +15,14 @@ namespace Couchbase.Extensions.Encryption
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/ICryptoProvider.cs
+++ b/src/Couchbase.Extensions.Encryption/ICryptoProvider.cs
@@ -62,23 +62,14 @@ namespace Couchbase.Extensions.Encryption
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/IKeystoreProvider.cs
+++ b/src/Couchbase.Extensions.Encryption/IKeystoreProvider.cs
@@ -8,23 +8,14 @@
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/Providers/AesCryptoProvider.cs
+++ b/src/Couchbase.Extensions.Encryption/Providers/AesCryptoProvider.cs
@@ -67,23 +67,14 @@ namespace Couchbase.Extensions.Encryption.Providers
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/Providers/RsaCryptoProvider.cs
+++ b/src/Couchbase.Extensions.Encryption/Providers/RsaCryptoProvider.cs
@@ -141,23 +141,14 @@ namespace Couchbase.Extensions.Encryption.Providers
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/Stores/CspKeyStore.cs
+++ b/src/Couchbase.Extensions.Encryption/Stores/CspKeyStore.cs
@@ -16,23 +16,14 @@ namespace Couchbase.Extensions.Encryption.Stores
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/Stores/FileSystemKeyStore.cs
+++ b/src/Couchbase.Extensions.Encryption/Stores/FileSystemKeyStore.cs
@@ -49,23 +49,14 @@ namespace Couchbase.Extensions.Encryption.Stores
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/Stores/InMemoryKeyStore.cs
+++ b/src/Couchbase.Extensions.Encryption/Stores/InMemoryKeyStore.cs
@@ -20,23 +20,14 @@ namespace Couchbase.Extensions.Encryption.Stores
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/Stores/InsecureKeyStore.cs
+++ b/src/Couchbase.Extensions.Encryption/Stores/InsecureKeyStore.cs
@@ -33,23 +33,14 @@ namespace Couchbase.Extensions.Encryption.Stores
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/src/Couchbase.Extensions.Encryption/Utils/MemberInfoExtensions.cs
+++ b/src/Couchbase.Extensions.Encryption/Utils/MemberInfoExtensions.cs
@@ -25,23 +25,14 @@ namespace Couchbase.Extensions.Encryption.Utils
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/tests/Couchbase.Extensions.Encryption.IntegrationTests/FieldEncryptionTests.cs
+++ b/tests/Couchbase.Extensions.Encryption.IntegrationTests/FieldEncryptionTests.cs
@@ -299,3 +299,15 @@ namespace Couchbase.Extensions.Encryption.IntegrationTests
         }
     }
 }
+
+#region [License information]
+/* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
+ *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
+ * ************************************************************/
+#endregion

--- a/tests/Couchbase.Extensions.Encryption.IntegrationTests/TestConfiguration.cs
+++ b/tests/Couchbase.Extensions.Encryption.IntegrationTests/TestConfiguration.cs
@@ -18,3 +18,15 @@ namespace Couchbase.Extensions.Encryption.IntegrationTests
         }
     }
 }
+
+#region [License information]
+/* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
+ *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
+ * ************************************************************/
+#endregion

--- a/tests/Couchbase.Extensions.Encryption.IntegrationTests/configuration.json
+++ b/tests/Couchbase.Extensions.Encryption.IntegrationTests/configuration.json
@@ -7,8 +7,20 @@
     ],
     "Buckets": [
       {
-        "Name": "travel-sample"
+        "Name": "default"
       }
     ]
   }
 }
+
+
+/* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
+ *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
+ * ************************************************************/
+

--- a/tests/Couchbase.Extensions.Encryption.UnitTests/ClientConfigurationTests.cs
+++ b/tests/Couchbase.Extensions.Encryption.UnitTests/ClientConfigurationTests.cs
@@ -18,23 +18,14 @@ namespace Couchbase.Extensions.Encryption.UnitTests
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/tests/Couchbase.Extensions.Encryption.UnitTests/EncryptableFieldConverterTests.cs
+++ b/tests/Couchbase.Extensions.Encryption.UnitTests/EncryptableFieldConverterTests.cs
@@ -66,23 +66,14 @@ namespace Couchbase.Extensions.Encryption.UnitTests
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/tests/Couchbase.Extensions.Encryption.UnitTests/FieldEncryptionContractResolverTests.cs
+++ b/tests/Couchbase.Extensions.Encryption.UnitTests/FieldEncryptionContractResolverTests.cs
@@ -192,23 +192,14 @@ namespace Couchbase.Extensions.Encryption.UnitTests
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/tests/Couchbase.Extensions.Encryption.UnitTests/Providers/AesCryptoProviderTests.cs
+++ b/tests/Couchbase.Extensions.Encryption.UnitTests/Providers/AesCryptoProviderTests.cs
@@ -141,23 +141,14 @@ namespace Couchbase.Extensions.Encryption.UnitTests.Providers
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/tests/Couchbase.Extensions.Encryption.UnitTests/Providers/RsaCryptoProviderTests.cs
+++ b/tests/Couchbase.Extensions.Encryption.UnitTests/Providers/RsaCryptoProviderTests.cs
@@ -74,23 +74,14 @@ namespace Couchbase.Extensions.Encryption.UnitTests.Providers
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/tests/Couchbase.Extensions.Encryption.UnitTests/Stores/FileKeyStoreTests.cs
+++ b/tests/Couchbase.Extensions.Encryption.UnitTests/Stores/FileKeyStoreTests.cs
@@ -46,23 +46,14 @@ namespace Couchbase.Extensions.Encryption.UnitTests.Stores
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/tests/Couchbase.Extensions.Encryption.UnitTests/Stores/InMemoryKeyStoreTests.cs
+++ b/tests/Couchbase.Extensions.Encryption.UnitTests/Stores/InMemoryKeyStoreTests.cs
@@ -6,23 +6,14 @@ namespace Couchbase.Extensions.Encryption.UnitTests.Stores
     }
 }
 
-#region [ License information          ]
+#region [License information]
 /* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
  *
- *    @author Couchbase <info@couchbase.com>
- *    @copyright 2017 Couchbase, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
  * ************************************************************/
 #endregion

--- a/tests/Couchbase.Extensions.Encryption.UnitTests/TestConfiguration.cs
+++ b/tests/Couchbase.Extensions.Encryption.UnitTests/TestConfiguration.cs
@@ -18,3 +18,15 @@ namespace Couchbase.Extensions.Encryption.UnitTests
         }
     }
 }
+
+#region [License information]
+/* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
+ *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
+ * ************************************************************/
+#endregion

--- a/tests/Couchbase.Extensions.Encryption.UnitTests/configuration.json
+++ b/tests/Couchbase.Extensions.Encryption.UnitTests/configuration.json
@@ -3,7 +3,7 @@
     "Username": "Administrator",
     "Password" : "password",
     "Servers": [
-      "http://10.142.171.101:8091"
+      "http://localhost:8091"
     ],
     "Buckets": [
       {
@@ -12,3 +12,14 @@
     ]
   }
 }
+
+
+/* ************************************************************
+
+ *    Copyright (c) 2018 Couchbase, Inc.
+ *
+ *    Use of this software is subject to the Couchbase Inc.
+ *    Enterprise Subscription License Agreement which may be found
+ *    at https://www.couchbase.com/ESLA-11132015.
+
+ * ************************************************************/


### PR DESCRIPTION
Motivation
----------
Field Level Encryption is an Enterprise Edition feature.

Modifications
-------------
Add Enterprise license information to each source code footer.

Result
------
Each source file has an Enterprise License in the footer.